### PR TITLE
Add MSRC temporary team as security managers

### DIFF
--- a/otterdog/eclipse-threadx.jsonnet
+++ b/otterdog/eclipse-threadx.jsonnet
@@ -12,8 +12,7 @@ orgs.newOrg('eclipse-threadx') {
     packages_containers_internal: false,
     packages_containers_public: false,
     readers_can_create_discussions: true,
-    security_managers: [
-        "eclipsefdn-security",
+    security_managers+: [
         "tmp-threadx-msrc-vulnerabilities-transfer",
     ],
     two_factor_requirement: false,

--- a/otterdog/eclipse-threadx.jsonnet
+++ b/otterdog/eclipse-threadx.jsonnet
@@ -12,6 +12,10 @@ orgs.newOrg('eclipse-threadx') {
     packages_containers_internal: false,
     packages_containers_public: false,
     readers_can_create_discussions: true,
+    security_managers: [
+        "eclipsefdn-security",
+        "tmp-threadx-msrc-vulnerabilities-transfer",
+    ],
     two_factor_requirement: false,
     web_commit_signoff_required: false,
     workflows+: {


### PR DESCRIPTION
The MSRC team is a temporary team, serving as a subset of the committers team, and is temporarily granted the security manager role. This enables them to transfer existing vulnerability reports to this organization.