### PR TITLE
Updated Otterdog repo settings

### DIFF
--- a/otterdog/eclipse-threadx.jsonnet
+++ b/otterdog/eclipse-threadx.jsonnet
@@ -25,6 +25,7 @@ orgs.newOrg('iot.threadx', 'eclipse-threadx') {
   },
   _repositories+:: [
     orgs.extendRepo('.eclipsefdn') {
+      has_discussions: false,
       private_vulnerability_reporting_enabled: true
     },
     orgs.newRepo('.github') {
@@ -32,6 +33,7 @@ orgs.newOrg('iot.threadx', 'eclipse-threadx') {
       allow_update_branch: false,
       delete_branch_on_merge: false,
       dependabot_alerts_enabled: false,
+      has_discussions: true,
       private_vulnerability_reporting_enabled: true,
       web_commit_signoff_required: false
     },
@@ -40,6 +42,7 @@ orgs.newOrg('iot.threadx', 'eclipse-threadx') {
       allow_update_branch: false,
       delete_branch_on_merge: false,
       dependabot_security_updates_enabled: true,
+      has_discussions: true,
       private_vulnerability_reporting_enabled: true,
       web_commit_signoff_required: false,
       branch_protection_rules: [
@@ -52,26 +55,15 @@ orgs.newOrg('iot.threadx', 'eclipse-threadx') {
         }
       ]
     },
-    orgs.newRepo('demo-repository') {
-      allow_forking: false,
-      allow_merge_commit: true,
-      allow_update_branch: false,
-      delete_branch_on_merge: false,
-      dependabot_alerts_enabled: false,
-      description: "A code repository designed to show the best GitHub has to offer.",
-      has_wiki: false,
-      private: true,
-      web_commit_signoff_required: false
-    },
     orgs.newRepo('filex') {
       allow_merge_commit: true,
       allow_update_branch: false,
       default_branch: "master",
       delete_branch_on_merge: false,
       description: "Eclipse ThreadX - FileX is a high-performance, FAT-compatible file system that’s fully integrated with Eclipse ThreadX RTOS",
-      gh_pages_build_type: "legacy",
-      gh_pages_source_branch: "master",
-      gh_pages_source_path: "/",
+      dependabot_security_updates_enabled: true,
+      gh_pages_build_type: "workflow",
+      has_discussions: true,
       homepage: "https://github.com/eclipse-threadx/rtos-docs/blob/main/rtos-docs/filex/index.md",
       private_vulnerability_reporting_enabled: true,
       topics+: [
@@ -79,76 +71,50 @@ orgs.newOrg('iot.threadx', 'eclipse-threadx') {
       ],
       web_commit_signoff_required: false,
       rulesets: [
-        customRuleset('master')
+        customRuleset('main')
       ],
       environments: [
         orgs.newEnvironment('github-pages') {
           branch_policies+: [
-            "master"
+            "main"
           ],
           deployment_branch_policy: "selected"
         }
       ]
     },
-    orgs.newRepo('getting-started') {
-      allow_rebase_merge: false,
+    orgs.newRepo('guix') {
+      allow_merge_commit: true,
       allow_update_branch: false,
       default_branch: "master",
       delete_branch_on_merge: false,
-      description: "This Getting Started guide is a series of tutorials that shows device developers how to connect to Azure IoT using Eclipse ThreadX.",
-      gh_pages_build_type: "legacy",
-      gh_pages_source_branch: "master",
-      gh_pages_source_path: "/",
+      dependabot_security_updates_enabled: true,
+      description: "Eclipse ThreadX GUIX Studio provides a complete, embedded graphical user interface (GUI) library and design environment, facilitating the creation and maintenance of all graphical elements needed by your device.",
+      gh_pages_build_type: "workflow",
       has_discussions: true,
       has_projects: false,
-      has_wiki: false,
-      homepage: "https://learn.microsoft.com/azure/iot-develop",
+      homepage: "https://github.com/eclipse-threadx/rtos-docs/blob/main/rtos-docs/guix/index.md",
       private_vulnerability_reporting_enabled: true,
       topics+: [
-        "azure-iot",
         "eclipse-threadx",
+        "embedded",
+        "gui",
         "iot",
-        "iot-device",
-        "iot-hub",
         "mcu",
-        "microcontroller"
+        "microcontroller",
+        "rtos"
       ],
       web_commit_signoff_required: false,
-      branch_protection_rules: [
-        orgs.newBranchProtectionRule('master') {
-          required_approving_review_count: null,
-          required_status_checks+: [
-            "build (ubuntu-latest, Debug)",
-            "build (ubuntu-latest, Release)",
-            "build (windows-latest, Debug)",
-            "build (windows-latest, Release)"
-          ],
-          requires_conversation_resolution: true,
-          requires_linear_history: true,
-          requires_pull_request: false,
-          requires_strict_status_checks: true,
-        }
+      rulesets: [
+        customRuleset('main')
       ],
       environments: [
         orgs.newEnvironment('github-pages') {
           branch_policies+: [
-            "master"
+            "main"
           ],
           deployment_branch_policy: "selected"
         }
       ]
-    },
-    orgs.newRepo('vulnerability-management') {
-      private: true,
-      allow_forking: false,
-      allow_update_branch: false,
-      has_issues: true,
-      has_discussions: false,
-      has_projects: true,
-      default_branch: "main",
-      dependabot_alerts_enabled: false,
-      description: "Private repository used to manage vulnerability-related tasks.",
-      private_vulnerability_reporting_enabled: false
     },
     orgs.newRepo('iot-devkit') {
       allow_rebase_merge: false,
@@ -158,7 +124,6 @@ orgs.newOrg('iot.threadx', 'eclipse-threadx') {
       description: "This guide is focused on the MXChip IoT DevKit (AZ3166).",
       has_discussions: true,
       has_projects: false,
-      has_wiki: false,
       homepage: "https://threadx.io",
       private_vulnerability_reporting_enabled: false,
       topics+: [
@@ -179,29 +144,6 @@ orgs.newOrg('iot.threadx', 'eclipse-threadx') {
         }
       ]
     },
-    orgs.newRepo('guix') {
-      allow_merge_commit: true,
-      allow_update_branch: false,
-      default_branch: "master",
-      delete_branch_on_merge: false,
-      dependabot_security_updates_enabled: true,
-      description: "Eclipse ThreadX GUIX Studio provides a complete, embedded graphical user interface (GUI) library and design environment, facilitating the creation and maintenance of all graphical elements needed by your device.",
-      gh_pages_build_type: "workflow",
-      has_projects: false,
-      has_wiki: false,
-      homepage: "https://github.com/eclipse-threadx/rtos-docs/blob/main/rtos-docs/guix/index.md",
-      private_vulnerability_reporting_enabled: true,
-      topics+: [
-        "eclipse-threadx",
-        "embedded",
-        "gui",
-        "iot",
-        "mcu",
-        "microcontroller",
-        "rtos"
-      ],
-      web_commit_signoff_required: false
-    },
     orgs.newRepo('levelx') {
       allow_merge_commit: true,
       allow_update_branch: false,
@@ -210,6 +152,7 @@ orgs.newOrg('iot.threadx', 'eclipse-threadx') {
       dependabot_security_updates_enabled: true,
       description: "Eclipse ThreadX - LevelX Provides Flash Wear Leveling for FileX and Stand Alone purposes.",
       gh_pages_build_type: "workflow",
+      has_discussions: true,
       has_projects: false,
       has_wiki: false,
       homepage: "https://github.com/eclipse-threadx/rtos-docs/blob/main/rtos-docs/levelx/index.md",
@@ -243,6 +186,7 @@ orgs.newOrg('iot.threadx', 'eclipse-threadx') {
       dependabot_security_updates_enabled: true,
       description: "Eclipse ThreadX - NetXDuo is an advanced, industrial-grade TCP/IP network stack designed specifically for deeply embedded real-time and IoT applications",
       gh_pages_build_type: "workflow",
+      has_discussions: true,
       has_projects: false,
       has_wiki: false,
       homepage: "https://github.com/eclipse-threadx/rtos-docs/blob/main/rtos-docs/netx-duo/index.md",
@@ -270,14 +214,6 @@ orgs.newOrg('iot.threadx', 'eclipse-threadx') {
         },
       ],
     },
-    orgs.newRepo('rtos-docs') {
-      allow_merge_commit: true,
-      allow_update_branch: false,
-      delete_branch_on_merge: false,
-      dependabot_alerts_enabled: false,
-      private_vulnerability_reporting_enabled: true,
-      web_commit_signoff_required: false
-    },
     orgs.newRepo('rtos-docs-asciidoc') {
       allow_merge_commit: true,
       allow_update_branch: false,
@@ -285,6 +221,7 @@ orgs.newOrg('iot.threadx', 'eclipse-threadx') {
       delete_branch_on_merge: false,
       dependabot_alerts_enabled: false,
       description: "Source of the Eclipse ThreadX documentation in AsciiDoc format. Supersedes rtos-docs.",
+      has_discussions: true,
       homepage: "https://threadx.io",
       private_vulnerability_reporting_enabled: true,
       topics+: [
@@ -315,23 +252,61 @@ orgs.newOrg('iot.threadx', 'eclipse-threadx') {
       delete_branch_on_merge: false,
       dependabot_alerts_enabled: false,
       description: "Rendition of the Eclipse ThreadX documentation in HTML format. For website integration only.",
+      has_discussions: false,
       homepage: "https://threadx.io",
       private_vulnerability_reporting_enabled: false,
-      web_commit_signoff_required: false
+      web_commit_signoff_required: false,
+      rulesets: [
+        customRuleset('master')
+      ],
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "master"
+          ],
+          deployment_branch_policy: "selected"
+        }
+      ]
     },
-    orgs.newRepo('samples') {
+    orgs.newRepo('samplex') {
       allow_merge_commit: true,
       allow_update_branch: false,
-      default_branch: "master",
+      default_branch: "main",
       delete_branch_on_merge: false,
-      description: "A collection of complete sample workspaces and projects for popular development boards from ST, NXP, Renesas, Microchip and Microsoft using popular IDEs and toolchains, including IAR, ARM, STM32CubeIDE, MCUXpresso, MPLAB, Visual Studio, and Visual Studio Code.",
+      dependabot_security_updates_enabled: true,
+      description: "Eclipse ThreadX samples and demos",
+      gh_pages_build_type: "workflow",
+      has_discussions: true,
       has_projects: false,
-      has_wiki: false,
-      homepage: "",
+      homepage: "https://threadx.io",
       private_vulnerability_reporting_enabled: true,
-      web_commit_signoff_required: false
+      topics+: [
+        "eclipse-threadx",
+        "embedded",
+        "iot",
+        "mcu",
+        "microcontroller",
+        "rtos",
+        "samples",
+        "demos",
+        "threadx-samples",
+        "threadx-demos"
+      ],
+      web_commit_signoff_required: false,
+      rulesets: [
+        customRuleset('main')
+      ],
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "main"
+          ],
+          deployment_branch_policy: "selected"
+        }
+      ]
     },
     orgs.newRepo('supported-platforms') {
+      has_discussions: true,
     },
     orgs.newRepo('threadx') {
       allow_merge_commit: true,
@@ -341,6 +316,7 @@ orgs.newOrg('iot.threadx', 'eclipse-threadx') {
       dependabot_security_updates_enabled: true,
       description: "Eclipse ThreadX is an advanced real-time operating system (RTOS) designed specifically for deeply embedded applications.",
       gh_pages_build_type: "workflow",
+      has_discussions: true,
       has_projects: false,
       homepage: "https://github.com/eclipse-threadx/rtos-docs/blob/main/rtos-docs/threadx/index.md",
       private_vulnerability_reporting_enabled: true,
@@ -366,27 +342,52 @@ orgs.newOrg('iot.threadx', 'eclipse-threadx') {
         }
       ]
     },
-    orgs.newRepo('threadx-learn-samples') {
-      allow_merge_commit: true,
-      allow_update_branch: false,
-      delete_branch_on_merge: false,
-      dependabot_alerts_enabled: false,
-      description: "Azure RTOS Microsoft Learn Samples",
-      has_issues: false,
-      homepage: "",
-      is_template: true,
-      private_vulnerability_reporting_enabled: true,
-      web_commit_signoff_required: false
-    },
     orgs.newRepo('tracex') {
       allow_merge_commit: true,
       allow_update_branch: false,
       delete_branch_on_merge: false,
+      has_discussions: true,
       private_vulnerability_reporting_enabled: true,
       web_commit_signoff_required: false,
       rulesets: [
         customRuleset('main')
       ],
+    },
+    orgs.newRepo('trustedx') {
+      private: true,
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      default_branch: "main",
+      delete_branch_on_merge: false,
+      dependabot_security_updates_enabled: true,
+      description: "Eclipse Trustable Software Framework artefacts for Eclipse ThreadX and its companion components",
+      gh_pages_build_type: "workflow",
+      has_discussions: true,
+      has_projects: false,
+      homepage: "https://threadxalliance.org",
+      private_vulnerability_reporting_enabled: true,
+      topics+: [
+        "eclipse-threadx",
+        "embedded",
+        "iot",
+        "mcu",
+        "microcontroller",
+        "rtos",
+        "safety",
+        "safety-critical"
+      ],
+      web_commit_signoff_required: false,
+      rulesets: [
+        customRuleset('main')
+      ],
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "main"
+          ],
+          deployment_branch_policy: "selected"
+        }
+      ]
     },
     orgs.newRepo('usbx') {
       allow_merge_commit: true,
@@ -423,6 +424,98 @@ orgs.newOrg('iot.threadx', 'eclipse-threadx') {
           deployment_branch_policy: "selected"
         }
       ]
+    },
+    orgs.newRepo('vulnerability-management') {
+      private: true,
+      allow_forking: false,
+      allow_update_branch: false,
+      has_issues: true,
+      has_discussions: false,
+      has_projects: true,
+      default_branch: "main",
+      dependabot_alerts_enabled: false,
+      description: "Private repository used to manage vulnerability-related tasks.",
+      private_vulnerability_reporting_enabled: false
+    },
+    // Archived repositories: Do not change settings.
+    orgs.newRepo('getting-started') {
+      archived: true,
+      allow_rebase_merge: false,
+      allow_update_branch: false,
+      default_branch: "master",
+      delete_branch_on_merge: false,
+      description: "ARCHIVED - This Getting Started guide is a series of tutorials that shows device developers how to connect to Azure IoT using Eclipse ThreadX.",
+      gh_pages_build_type: "legacy",
+      gh_pages_source_branch: "master",
+      gh_pages_source_path: "/",
+      has_discussions: false,
+      has_projects: false,
+      has_wiki: false,
+      homepage: "https://learn.microsoft.com/azure/iot-develop",
+      private_vulnerability_reporting_enabled: true,
+      web_commit_signoff_required: false,
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('master') {
+          required_approving_review_count: null,
+          required_status_checks+: [
+            "build (ubuntu-latest, Debug)",
+            "build (ubuntu-latest, Release)",
+            "build (windows-latest, Debug)",
+            "build (windows-latest, Release)"
+          ],
+          requires_conversation_resolution: true,
+          requires_linear_history: true,
+          requires_pull_request: false,
+          requires_strict_status_checks: true,
+        }
+      ],
+      environments: [
+        orgs.newEnvironment('github-pages') {
+          branch_policies+: [
+            "master"
+          ],
+          deployment_branch_policy: "selected"
+        }
+      ]
+    },
+    orgs.newRepo('rtos-docs') {
+      archived: true,
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      description: "ARCHIVED - Eclipse ThreadX documentation in markdown format. Use rtos-docs-asciidoc instead.",
+      has_discussions: false,
+      dependabot_alerts_enabled: false,
+      private_vulnerability_reporting_enabled: true,
+      web_commit_signoff_required: false
+    },
+    orgs.newRepo('samples') {
+      archived: true,
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      default_branch: "master",
+      delete_branch_on_merge: false,
+      description: "ARCHIVED - A collection of complete sample workspaces and projects for popular development boards from ST, NXP, Renesas, Microchip and Microsoft using popular IDEs and toolchains, including IAR, ARM, STM32CubeIDE, MCUXpresso, MPLAB, Visual Studio, and Visual Studio Code.",
+      has_discussions: false,
+      has_projects: false,
+      has_wiki: false,
+      homepage: "",
+      private_vulnerability_reporting_enabled: true,
+      web_commit_signoff_required: false
+    },
+    orgs.newRepo('threadx-learn-samples') {
+      archived: true,
+      allow_merge_commit: true,
+      allow_update_branch: false,
+      delete_branch_on_merge: false,
+      dependabot_alerts_enabled: false,
+      description: "ARCHIVED - Azure RTOS Microsoft Learn Samples",
+      has_discussions: false,
+      has_issues: false,
+      homepage: "",
+      is_template: true,
+      private_vulnerability_reporting_enabled: true,
+      web_commit_signoff_required: false
     }
   ]
 }

--- a/otterdog/eclipse-threadx.jsonnet
+++ b/otterdog/eclipse-threadx.jsonnet
@@ -355,6 +355,7 @@ orgs.newOrg('iot.threadx', 'eclipse-threadx') {
     },
     orgs.newRepo('trustedx') {
       private: true,
+      allow_forking: false,
       allow_merge_commit: true,
       allow_update_branch: false,
       default_branch: "main",


### PR DESCRIPTION
Archived selected repositories and moved them into a dedicated archived section at the bottom of the repository list.

Normalized repository ordering and discussion settings across active and archived repositories.

Aligned FileX and GUIX with the ThreadX baseline for dependabot, rulesets, environments, and GitHub Pages configuration.

Added SampleX and TrustedX repository definitions with branch protection and environment settings targeting main.